### PR TITLE
reset the sliderValue

### DIFF
--- a/PhotoTweaks/PhotoTweaks/PhotoTweakView.m
+++ b/PhotoTweaks/PhotoTweaks/PhotoTweakView.m
@@ -732,7 +732,7 @@ typedef NS_ENUM(NSInteger, CropCornerType) {
         self.cropView.center = self.scrollView.center;
         [self updateMasks:NO];
         
-        [self.slider setValue:0.5 animated:YES];
+        [self.slider setValue:0 animated:YES];
     }];
 }
 


### PR DESCRIPTION
considering the code below:
_slider.minimumValue = -self.maxRotationAngle;
_slider.maximumValue = self.maxRotationAngle;
I think the value:0  more suitable.
